### PR TITLE
Multiple grammar corrections

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -8,6 +8,7 @@ module.exports = grammar({
   // final argument is optional
   conflicts: ($) => [
     [$.new_session_directive],
+    [$.new_window_directive],
     [$.server_access_directive],
     [$.set_environment_directive],
     [$.show_environment_directive],
@@ -485,15 +486,28 @@ module.exports = grammar({
       command(
         $,
         choice("new-window", "neww"),
-        cmd_opts(
-          options($, "abdkPS"),
-          $._start_directory,
-          $._environment,
-          $._format,
-          $._window_name,
-          $._target_window
-        ),
-        $._shell
+        choice(
+          seq(
+            cmd_opts(
+              options($, "abdkPS"),
+              $._start_directory,
+              $._environment,
+              $._format,
+              $._window_name,
+              $._target_window
+            ),
+            $._shell
+          ),
+          cmd_opts(
+            options($, "abdkPS"),
+            $._start_directory,
+            $._environment,
+            $._format,
+            $._window_name,
+            $._target_window
+          ),
+          $._shell
+        )
       ),
     next_layout_directive: ($) =>
       command($, choice("next-layout", "nextl"), cmd_opts($._target_window)),

--- a/grammar.js
+++ b/grammar.js
@@ -468,7 +468,7 @@ module.exports = grammar({
       command(
         $,
         choice("new-session", "new"),
-        cmd_opts0(
+        cmd_opts(
           options($, "AdDEPX"),
           $._start_directory,
           $._environment,
@@ -651,18 +651,17 @@ module.exports = grammar({
         $.layout_name
       ),
     _title: ($) => option($, "T", alias($._string, $.title)),
-    // use cmd_opts0() for commands without any mandatory argument
     select_pane_directive: ($) =>
       command(
         $,
         choice("select-pane", "selectp"),
-        cmd_opts0(options($, "DdeLlMmRUZ"), $._target_pane, $._title)
+        cmd_opts(options($, "DdeLlMmRUZ"), $._target_pane, $._title)
       ),
     select_window_directive: ($) =>
       command(
         $,
         choice("select-window", "selectw"),
-        cmd_opts0(options($, "lnpT"), $._target_window)
+        cmd_opts(options($, "lnpT"), $._target_window)
       ),
     _keys: ($) => spaceSep1($.key),
     send_keys_directive: ($) =>
@@ -901,20 +900,12 @@ function sep1(rule, separator) {
   return seq(rule, repeat(seq(separator, rule)));
 }
 
-function sep(rule, separator) {
-  return seq(optional(rule), repeat(seq(separator, rule)));
-}
-
 function commaSep1(rule) {
   return sep1(rule, ",");
 }
 
 function spaceSep1(rule) {
   return sep1(rule, " ");
-}
-
-function spaceSep(rule) {
-  return sep(rule, " ");
 }
 
 function quoted_string(char, name) {
@@ -941,8 +932,4 @@ function option($, char, ...arg) {
 
 function cmd_opts(...args) {
   return repeat(choice(...args));
-}
-
-function cmd_opts0(...args) {
-  return spaceSep(choice(...args));
 }

--- a/grammar.js
+++ b/grammar.js
@@ -888,7 +888,7 @@ module.exports = grammar({
     comment: (_) => /#[^\n]*/,
     _eol: (_) => /\r?\n/,
     _space: (_) => prec(-1, repeat1(/[ \t]/)),
-    _end: ($) => seq(optional($._space), optional($.comment), $._eol),
+    _end: ($) => seq(optional($.comment), $._eol),
   },
 });
 

--- a/grammar.js
+++ b/grammar.js
@@ -486,28 +486,15 @@ module.exports = grammar({
       command(
         $,
         choice("new-window", "neww"),
-        choice(
-          seq(
-            cmd_opts(
-              options($, "abdkPS"),
-              $._start_directory,
-              $._environment,
-              $._format,
-              $._window_name,
-              $._target_window
-            ),
-            $._shell
-          ),
-          cmd_opts(
-            options($, "abdkPS"),
-            $._start_directory,
-            $._environment,
-            $._format,
-            $._window_name,
-            $._target_window
-          ),
-          $._shell
-        )
+        cmd_opts(
+          options($, "abdkPS"),
+          $._start_directory,
+          $._environment,
+          $._format,
+          $._window_name,
+          $._target_window
+        ),
+        optional($._shell)
       ),
     next_layout_directive: ($) =>
       command($, choice("next-layout", "nextl"), cmd_opts($._target_window)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "tmux",
   "rules": {
     "file": {
@@ -7161,18 +7162,6 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_space"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
               "name": "comment"
             },
             {
@@ -7217,5 +7206,6 @@
   "precedences": [],
   "externals": [],
   "inline": [],
-  "supertypes": []
+  "supertypes": [],
+  "reserved": {}
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3956,8 +3956,16 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "_shell"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_shell"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -7189,6 +7197,9 @@
   "conflicts": [
     [
       "new_session_directive"
+    ],
+    [
+      "new_window_directive"
     ],
     [
       "server_access_directive"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3759,129 +3759,57 @@
           "value": "command"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "-[AdDEPX]+"
-                      },
-                      "named": true,
-                      "value": "command_line_option"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_start_directory"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_environment"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_flags"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_format"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_window_name"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_session_name"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_group_name"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_width"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_height"
-                    }
-                  ]
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "-[AdDEPX]+"
                 },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": " "
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "-[AdDEPX]+"
-                        },
-                        "named": true,
-                        "value": "command_line_option"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_start_directory"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_environment"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_flags"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_format"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_window_name"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_session_name"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_group_name"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_width"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_height"
-                      }
-                    ]
-                  }
-                ]
+                "named": true,
+                "value": "command_line_option"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_start_directory"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_environment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_flags"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_format"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_window_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_session_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_group_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_width"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_height"
               }
-            }
-          ]
+            ]
+          }
         },
         {
           "type": "CHOICE",
@@ -5307,73 +5235,29 @@
           "value": "command"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "-[DdeLlMmRUZ]+"
-                      },
-                      "named": true,
-                      "value": "command_line_option"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_target_pane"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_title"
-                    }
-                  ]
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "-[DdeLlMmRUZ]+"
                 },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": " "
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "-[DdeLlMmRUZ]+"
-                        },
-                        "named": true,
-                        "value": "command_line_option"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_target_pane"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_title"
-                      }
-                    ]
-                  }
-                ]
+                "named": true,
+                "value": "command_line_option"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_target_pane"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_title"
               }
-            }
-          ]
+            ]
+          }
         }
       ]
     },
@@ -5399,65 +5283,25 @@
           "value": "command"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "-[lnpT]+"
-                      },
-                      "named": true,
-                      "value": "command_line_option"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_target_window"
-                    }
-                  ]
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "-[lnpT]+"
                 },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": " "
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "-[lnpT]+"
-                        },
-                        "named": true,
-                        "value": "command_line_option"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_target_window"
-                      }
-                    ]
-                  }
-                ]
+                "named": true,
+                "value": "command_line_option"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_target_window"
               }
-            }
-          ]
+            ]
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5871,6 +5871,7 @@
   {
     "type": "file",
     "named": true,
+    "root": true,
     "fields": {},
     "children": {
       "multiple": true,

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,11 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +31,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -47,6 +53,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {
@@ -78,6 +85,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -92,7 +105,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -108,13 +121,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -128,15 +141,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -144,7 +165,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/test/corpus/example.txt
+++ b/test/corpus/example.txt
@@ -3,6 +3,8 @@ Example
 =======
 
 # https://github.com/tmux-plugins/tpm
+bind v split-window -h -c "#{pane_current_path}"
+bind v split-window -h
 set -g @plugin tmux-plugins/tpm
 setw -g pane-base-index 1
 set -g word-separators ' -_@'
@@ -52,6 +54,23 @@ new_window'
 
 (file
   (comment)
+  (bind_key_directive
+    (command)
+    (key)
+    (split_window_directive
+      (command)
+      (command_line_option)
+      (command_line_option)
+      (start_directory
+        (string
+          (variable
+            (variable_name))))))
+  (bind_key_directive
+    (command)
+    (key)
+    (split_window_directive
+      (command)
+      (command_line_option)))
   (set_option_directive
     (command)
     (command_line_option)

--- a/test/corpus/new-session.txt
+++ b/test/corpus/new-session.txt
@@ -1,0 +1,329 @@
+========================================
+new-session: Simple
+========================================
+new-session
+new
+
+---
+
+(file
+  (new_session_directive
+    (command))
+  (new_session_directive
+    (command)))
+
+========================================
+new-session: Flags
+========================================
+new-session -d
+new -d
+new-session -A
+new -A
+new-session -D
+new -D
+new-session -E
+new -E
+new-session -P
+new -P
+new-session -X
+new -X
+new-session -dP
+new -dP
+
+---
+
+(file
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option))
+  (new_session_directive
+    (command)
+    (command_line_option)))
+
+========================================
+new-session: Flags + Shell
+========================================
+new-session -d "top"
+new -d "top"
+new-session -P -F '#{session_name}:#{session_attached}'
+new -P -F '#{session_name}:#{session_attached}'
+
+---
+
+(file
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (string))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (string))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string))))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string)))))
+
+========================================
+new-session: Options
+========================================
+new-session -s dev
+new -s dev
+new-session -n editor
+new -n editor
+new-session -c ~/proj
+new -c ~/proj
+new-session -e PATH=/usr/local/bin -e MODE=dev
+new -e PATH=/usr/local/bin -e MODE=dev
+new-session -F '#{session_name}:'
+new -F '#{session_name}:'
+new-session -x 180 -y 48
+new -x 180 -y 48
+
+---
+
+(file
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (session_name))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (session_name))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (window_name))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (window_name))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (start_directory))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (start_directory))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string))))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string))))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (width)
+    (command_line_option)
+    (height))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (width)
+    (command_line_option)
+    (height)))
+
+========================================
+new-session: Options + Shell
+========================================
+new-session -s build -n logs -c ~/proj "npm run start"
+new -s build -n logs -c ~/proj "npm run start"
+new-session -e LANG=en_US.UTF-8 -e MODE=prod "bash -lc 'echo hello'"
+new -e LANG=en_US.UTF-8 -e MODE=prod "bash -lc 'echo hello'"
+
+---
+
+(file
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (session_name)
+    (command_line_option)
+    (window_name)
+    (command_line_option)
+    (start_directory)
+    (string))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (session_name)
+    (command_line_option)
+    (window_name)
+    (command_line_option)
+    (start_directory)
+    (string))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (string))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (string)))
+
+========================================
+new-session: Group (–t)
+========================================
+new-session -t mygroup
+new -t mygroup
+new-session -t existing:session
+new -t existing:session
+
+---
+
+(file
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (group_name))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (group_name))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (group_name))
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (group_name)))
+
+========================================
+new-session: Complex
+========================================
+# line continuations, many options, and a trailing comment
+new-session -d -P -F '#{session_name}:#{session_windows}' -s \
+ci -n "workers" -c ~/proj \
+-e MODE=ci -e COLOR=1 -x 160 -y 40 "bash -lc 'make test'"  # detached CI session
+new -d -P -F '#{session_name}:#{session_windows}' -s \
+ci -n "workers" -c ~/proj \
+-e MODE=ci -e COLOR=1 -x 160 -y 40 "bash -lc 'make test'"  # detached CI session
+
+---
+
+(file
+  (comment)
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string)))
+    (command_line_option)
+    (session_name)
+    (command_line_option)
+    (window_name
+      (string))
+    (command_line_option)
+    (start_directory)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (width)
+    (command_line_option)
+    (height)
+    (string))
+  (comment)
+  (new_session_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string)))
+    (command_line_option)
+    (session_name)
+    (command_line_option)
+    (window_name
+      (string))
+    (command_line_option)
+    (start_directory)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (width)
+    (command_line_option)
+    (height)
+    (string))
+  (comment))

--- a/test/corpus/new-window.txt
+++ b/test/corpus/new-window.txt
@@ -1,0 +1,297 @@
+===========
+Simple
+===========
+
+new-window
+neww
+new-window top
+neww top
+
+---
+
+(file
+  (new_window_directive
+    (command))
+  (new_window_directive
+    (command))
+  (new_window_directive
+    (command)
+    (shell))
+  (new_window_directive
+    (command)
+    (shell)))
+
+====================
+Flags
+====================
+
+new-window -a
+new-window -b
+new-window -d
+new-window -k
+new-window -P
+new-window -S
+new-window -abdkPS
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option)))
+
+====================
+Flags + Shell
+====================
+
+new-window -a top
+new-window -b top
+new-window -d top
+new-window -k top
+new-window -P top
+new-window -S top
+new-window -abdkPS top
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell)))
+
+==================
+Options
+==================
+
+new-window -c /tmp
+new-window -e VAR=value
+new-window -e VAR1=value1 -e VAR2=value2
+new-window -F "#{session_name}:#{window_index}"
+new-window -n mywin
+new-window -t :2
+new-window -c /tmp -e VAR=value -e VAR2=value2 -F "#{session_name}:#{window_index}" -n mywin -t :2
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))
+        (variable
+          (variable_name)))))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (window_name))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))
+        (variable
+          (variable_name))))
+    (command_line_option)
+    (window_name)
+    (command_line_option)
+    (window)))
+
+===============
+Options + Shell
+===============
+
+new-window -c /tmp top
+new-window -e VAR=value top
+new-window -e VAR1=value1 -e VAR2=value2 top
+new-window -F "#{session_name}:#{window_index}" top
+new-window -n mywin top
+new-window -t :2 top
+new-window -c /tmp -e VAR=value -e VAR2=value2 -F "#{session_name}:#{window_index}" -n mywin  -t :2 top
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))
+        (variable
+          (variable_name))))
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (window_name)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (window)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))
+        (variable
+          (variable_name))))
+    (command_line_option)
+    (window_name)
+    (command_line_option)
+    (window)
+    (shell)))
+
+===============
+Complex
+===============
+
+new-window -P -F "#{window_id}" -n scratch vim
+new-window -e VAR1=foo -e VAR2=bar -n envtest bash
+new-window -k -t :3
+neww -c ~/projects -t :2 "make build"
+
+new-window -c "#{pane_current_path}"
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))))
+    (command_line_option)
+    (window_name)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (window_name)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (window))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (command_line_option)
+    (window)
+    (string))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory
+      (string
+        (variable
+          (variable_name))))))
+

--- a/test/corpus/new-window.txt
+++ b/test/corpus/new-window.txt
@@ -251,6 +251,7 @@ new-window -k -t :3
 neww -c ~/projects -t :2 "make build"
 
 new-window -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
 
 ---
 
@@ -293,5 +294,15 @@ new-window -c "#{pane_current_path}"
     (start_directory
       (string
         (variable
-          (variable_name))))))
+          (variable_name)))))
+  (bind_key_directive
+    (command)
+    (key)
+    (new_window_directive
+      (command)
+      (command_line_option)
+      (start_directory
+        (string
+          (variable
+            (variable_name)))))))
 

--- a/test/corpus/select-pane.txt
+++ b/test/corpus/select-pane.txt
@@ -1,0 +1,268 @@
+========================================
+select-pane: Simple
+========================================
+select-pane
+selectp
+
+---
+
+(file
+  (select_pane_directive
+    (command))
+  (select_pane_directive
+    (command)))
+
+========================================
+select-pane: Flags
+========================================
+select-pane -D
+selectp -D
+select-pane -L
+selectp -L
+select-pane -R
+selectp -R
+select-pane -U
+selectp -U
+select-pane -Z
+selectp -Z
+select-pane -l
+selectp -l
+select-pane -e
+selectp -e
+select-pane -d
+selectp -d
+select-pane -m
+selectp -m
+select-pane -M
+selectp -M
+select-pane -LR
+selectp -LR
+
+---
+
+(file
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option))
+  (select_pane_directive
+    (command)
+    (command_line_option)))
+
+========================================
+select-pane: Options
+========================================
+select-pane -t %3
+selectp -t %3
+select-pane -t :1.2
+selectp -t :1.2
+select-pane -T 'logs'
+selectp -T 'logs'
+select-pane -T "build #2"
+selectp -T "build #2"
+
+---
+
+(file
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (pane))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (pane))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (pane))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (pane))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (title
+      (raw_string
+        (__string))))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (title
+      (raw_string
+        (__string))))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (title
+      (string
+        (variable
+          (variable_name)))))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (title
+      (string
+        (variable
+          (variable_name))))))
+
+========================================
+select-pane: Flags + Options
+========================================
+select-pane -R -t %5
+selectp -R -t %5
+select-pane -l -t :3.0
+selectp -l -t :3.0
+select-pane -Z -T 'stay-zoomed'
+selectp -Z -T 'stay-zoomed'
+select-pane -e -t %1 -T 'input on'
+selectp -e -t %1 -T 'input on'
+
+---
+
+(file
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (pane))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (pane))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (pane))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (pane))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (title
+      (raw_string
+        (__string))))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (title
+      (raw_string
+        (__string))))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (pane)
+    (command_line_option)
+    (title
+      (raw_string
+        (__string))))
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (pane)
+    (command_line_option)
+    (title
+      (raw_string
+        (__string)))))
+
+========================================
+select-pane: Complex
+========================================
+# mixed ordering, bundled flags, continuation, and trailing comment
+select-pane -dZ -t \
+%7 -T "ops pane"  # keep zoom, disable input, target %7
+selectp -dZ -t \
+%7 -T "ops pane"  # keep zoom, disable input, target %7
+
+---
+
+(file
+  (comment)
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (pane)
+    (command_line_option)
+    (title
+      (string)))
+  (comment)
+  (select_pane_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (pane)
+    (command_line_option)
+    (title
+      (string)))
+  (comment))
+

--- a/test/corpus/select-window.txt
+++ b/test/corpus/select-window.txt
@@ -1,0 +1,212 @@
+========================================
+select-window: Simple
+========================================
+select-window
+selectw
+
+---
+
+(file
+  (select_window_directive
+    (command))
+  (select_window_directive
+    (command)))
+
+========================================
+select-window: Flags
+========================================
+select-window -l
+selectw -l
+select-window -n
+selectw -n
+select-window -p
+selectw -p
+select-window -T
+selectw -T
+select-window -ln
+selectw -ln
+select-window -lT
+selectw -lT
+
+---
+
+(file
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option)))
+
+========================================
+select-window: Options
+========================================
+select-window -t :3
+selectw -t :3
+select-window -t mysession:2
+selectw -t mysession:2
+select-window -t @42
+selectw -t @42
+select-window -t :+
+selectw -t :+
+select-window -t 'proj alpha:4'
+selectw -t 'proj alpha:4'
+
+---
+
+(file
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window
+      (raw_string
+        (__string))))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window
+      (raw_string
+        (__string)))))
+
+========================================
+select-window: Flags + Options
+========================================
+select-window -n -t :1
+selectw -n -t :1
+select-window -t :2 -p
+selectw -t :2 -p
+select-window -lT -t mysession:7
+selectw -lT -t mysession:7
+select-window -T -t @5
+selectw -T -t @5
+
+---
+
+(file
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window)
+    (command_line_option))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (window))
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (window)))
+
+========================================
+select-window: Complex
+========================================
+select-window -t \
+:5 -ln  # jump to last/next behavior, target :5
+selectw -t \
+:5 -ln  # jump to last/next behavior, target :5
+
+---
+
+(file
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window)
+    (command_line_option))
+  (comment)
+  (select_window_directive
+    (command)
+    (command_line_option)
+    (window)
+    (command_line_option))
+  (comment))
+

--- a/test/corpus/split-window.txt
+++ b/test/corpus/split-window.txt
@@ -1,0 +1,350 @@
+========================================
+split-window: Simple
+========================================
+split-window
+splitw
+
+---
+
+(file
+  (split_window_directive
+    (command))
+  (split_window_directive
+    (command)))
+
+========================================
+split-window: Flags
+========================================
+split-window -h
+splitw -h
+split-window -v
+splitw -v
+split-window -b
+splitw -b
+split-window -f
+splitw -f
+split-window -d
+splitw -d
+split-window -Z
+splitw -Z
+split-window -P
+splitw -P
+split-window -I
+splitw -I
+
+---
+
+(file
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option)))
+
+========================================
+split-window: Options
+========================================
+split-window -l 10
+splitw -l 10
+split-window -l 50%
+splitw -l 50%
+split-window -t %3
+splitw -t %3
+split-window -t :1.2
+splitw -t :1.2
+split-window -c ~/proj
+splitw -c ~/proj
+split-window -e PATH=/usr/local/bin -e MODE=dev
+splitw -e PATH=/usr/local/bin -e MODE=dev
+split-window -F '#{pane_id}'
+splitw -F '#{pane_id}'
+
+---
+
+(file
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (size))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (size))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (size))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (size))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (start_directory))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (start_directory))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string))))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string)))))
+
+========================================
+split-window: Options + Shell
+========================================
+split-window -c ~/proj "bash -lc 'echo hi'"
+splitw -c ~/proj "bash -lc 'echo hi'"
+split-window -e LANG=en_US.UTF-8 "top"
+splitw -e LANG=en_US.UTF-8 "top"
+split-window -l 30% -t %1 "printf hello"
+splitw -l 30% -t %1 "printf hello"
+
+---
+
+(file
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (string))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (string))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (string))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (string))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (size)
+    (command_line_option)
+    (pane)
+    (string))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (size)
+    (command_line_option)
+    (pane)
+    (string)))
+
+========================================
+split-window: Flags + Options
+========================================
+split-window -h -b -l 40% -t :2.0
+splitw -h -b -l 40% -t :2.0
+split-window -v -f -Z -t %5
+splitw -v -f -Z -t %5
+split-window -P -F '#{pane_index}:#{pane_active}' -t %1
+splitw -P -F '#{pane_index}:#{pane_active}' -t %1
+
+---
+
+(file
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (size)
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (size)
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string)))
+    (command_line_option)
+    (pane))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (format
+      (raw_string
+        (__string)))
+    (command_line_option)
+    (pane)))
+
+========================================
+split-window: Empty shell and stdin
+========================================
+split-window ''
+splitw ''
+split-window -dI
+splitw -dI
+
+---
+
+(file
+  (split_window_directive
+    (command)
+    (shell))
+  (split_window_directive
+    (command)
+    (shell))
+  (split_window_directive
+    (command)
+    (command_line_option))
+  (split_window_directive
+    (command)
+    (command_line_option)))
+
+========================================
+split-window: Complex
+========================================
+split-window -Z -h -b -l 60% -e MODE=ci -e COLOR=1 -t \
+:3.1 -c ~/proj "bash -lc 'make 2>&1 | tee /tmp/build.log'"
+splitw -Z -h -b -l 60% -e MODE=ci -e COLOR=1 -t \
+:3.1 -c ~/proj "bash -lc 'make 2>&1 | tee /tmp/build.log'"
+
+---
+
+(file
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (size)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (pane)
+    (command_line_option)
+    (start_directory)
+    (string))
+  (split_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (command_line_option)
+    (size)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (pane)
+    (command_line_option)
+    (start_directory)
+    (string)))
+


### PR DESCRIPTION
# Problem

I have found that in my personal `tmux.conf` there are quite a few syntax highlighting issues when inspecting tree-sitter I found that there are quite a few errors in the tree. When investigating GitHub issues I found #26 and #20 which was some of what I was experiencing.

---

Also just wanted to say thanks for the work you put into this project, I appreciate syntax highlighting 🖍️ 😄  

# Solution

Reviewing previous PRs it seems like the preference is to break them up when possible, so that is what I did here
*(If that is not preferred then just simply keep this PR open as it contains all fixes)*. 

**If merging PRs one at a time this should be merged last.**

Contains the following:

One of the main issues I found was `_end` contains `optional($._space)` which messes with a lot of commands. If I am being 100% honest I don't completely understand the fix. But it was causing tree-sitter to reduce early in quite a few instances. Because of my lack of certainty I ended up writing more tests which all seemed to have positive results.

Changed `new-window` so `shell` isn't required. When looking at [latest man for tmux](https://man7.org/linux/man-pages/man1/tmux.1.html#COMMANDS) it specifically states.
>If shell-command is not specified, the value of the default-command option is used.

Lastly I removed all `cmd_opts0` in favor of `cmd_opts` because from my understanding the grammar already states whitespace is `extra` so `cmd_opts` is sufficient.

# Test Results

The following are test results based on the new tests I had written [here](https://github.com/NicholasMata/tree-sitter-tmux/tree/fixes/grammar-issues/test/corpus) 
The `Example` test being referred to below is the updated one referenced in tests folder above. The updated one contains two more cases and all the original `Example` tests pass on all branches.

Current main branch results:
```
  example:
      1. ✗ Example (Updated)
  new-session:
      2. ✓ new-session: Simple
      3. ✓ new-session: Flags
      4. ✗ new-session: Flags + Shell
      5. ✓ new-session: Options
      6. ✗ new-session: Options + Shell
      7. ✓ new-session: Group (–t)
      8. ✗ new-session: Complex
  new-window:
      9. ✗ Simple
     10. ✗ Flags
     11. ✓ Flags + Shell
     12. ✗ Options
     13. ✓ Options + Shell
     14. ✗ Complex
  select-pane:
     15. ✓ select-pane: Simple
     16. ✓ select-pane: Flags
     17. ✓ select-pane: Options
     18. ✓ select-pane: Flags + Options
     19. ✗ select-pane: Complex
  select-window:
     20. ✓ select-window: Simple
     21. ✓ select-window: Flags
     22. ✓ select-window: Options
     23. ✓ select-window: Flags + Options
     24. ✗ select-window: Complex
  split-window:
     25. ✓ split-window: Simple
     26. ✗ split-window: Flags
     27. ✗ split-window: Options
     28. ✗ split-window: Options + Shell
     29. ✗ split-window: Flags + Options
     30. ✗ split-window: Empty shell and stdin
     31. ✗ split-window: Complex
```

After changes from PR all tests pass
```
  example:
      1. ✓ Example (Updated)
  new-session:
      2. ✓ new-session: Simple
      3. ✓ new-session: Flags
      4. ✓ new-session: Flags + Shell
      5. ✓ new-session: Options
      6. ✓ new-session: Options + Shell
      7. ✓ new-session: Group (–t)
      8. ✓ new-session: Complex
  new-window:
      9. ✓ Simple
     10. ✓ Flags
     11. ✓ Flags + Shell
     12. ✓ Options
     13. ✓ Options + Shell
     14. ✓ Complex
  select-pane:
     15. ✓ select-pane: Simple
     16. ✓ select-pane: Flags
     17. ✓ select-pane: Options
     18. ✓ select-pane: Flags + Options
     19. ✓ select-pane: Complex
  select-window:
     20. ✓ select-window: Simple
     21. ✓ select-window: Flags
     22. ✓ select-window: Options
     23. ✓ select-window: Flags + Options
     24. ✓ select-window: Complex
  split-window:
     25. ✓ split-window: Simple
     26. ✓ split-window: Flags
     27. ✓ split-window: Options
     28. ✓ split-window: Options + Shell
     29. ✓ split-window: Flags + Options
     30. ✓ split-window: Empty shell and stdin
     31. ✓ split-window: Complex
```

*This is my first Tree-sitter grammar change. I relied on tests to guide the fixes and kept the diff minimal. I’m happy to make changes if there’s a cleaner approach.*