### PR TITLE
Fixes Most Grammar Issues + new-window change

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -8,6 +8,7 @@ module.exports = grammar({
   // final argument is optional
   conflicts: ($) => [
     [$.new_session_directive],
+    [$.new_window_directive],
     [$.server_access_directive],
     [$.set_environment_directive],
     [$.show_environment_directive],
@@ -485,15 +486,28 @@ module.exports = grammar({
       command(
         $,
         choice("new-window", "neww"),
-        cmd_opts(
-          options($, "abdkPS"),
-          $._start_directory,
-          $._environment,
-          $._format,
-          $._window_name,
-          $._target_window
-        ),
-        $._shell
+        choice(
+          seq(
+            cmd_opts(
+              options($, "abdkPS"),
+              $._start_directory,
+              $._environment,
+              $._format,
+              $._window_name,
+              $._target_window
+            ),
+            $._shell
+          ),
+          cmd_opts(
+            options($, "abdkPS"),
+            $._start_directory,
+            $._environment,
+            $._format,
+            $._window_name,
+            $._target_window
+          ),
+          $._shell
+        )
       ),
     next_layout_directive: ($) =>
       command($, choice("next-layout", "nextl"), cmd_opts($._target_window)),

--- a/grammar.js
+++ b/grammar.js
@@ -888,7 +888,7 @@ module.exports = grammar({
     comment: (_) => /#[^\n]*/,
     _eol: (_) => /\r?\n/,
     _space: (_) => prec(-1, repeat1(/[ \t]/)),
-    _end: ($) => seq(optional($._space), optional($.comment), $._eol),
+    _end: ($) => seq(optional($.comment), $._eol),
   },
 });
 

--- a/grammar.js
+++ b/grammar.js
@@ -486,28 +486,15 @@ module.exports = grammar({
       command(
         $,
         choice("new-window", "neww"),
-        choice(
-          seq(
-            cmd_opts(
-              options($, "abdkPS"),
-              $._start_directory,
-              $._environment,
-              $._format,
-              $._window_name,
-              $._target_window
-            ),
-            $._shell
-          ),
-          cmd_opts(
-            options($, "abdkPS"),
-            $._start_directory,
-            $._environment,
-            $._format,
-            $._window_name,
-            $._target_window
-          ),
-          $._shell
-        )
+        cmd_opts(
+          options($, "abdkPS"),
+          $._start_directory,
+          $._environment,
+          $._format,
+          $._window_name,
+          $._target_window
+        ),
+        optional($._shell)
       ),
     next_layout_directive: ($) =>
       command($, choice("next-layout", "nextl"), cmd_opts($._target_window)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "tmux",
   "rules": {
     "file": {
@@ -7161,18 +7162,6 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_space"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
               "name": "comment"
             },
             {
@@ -7217,5 +7206,6 @@
   "precedences": [],
   "externals": [],
   "inline": [],
-  "supertypes": []
+  "supertypes": [],
+  "reserved": {}
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3956,8 +3956,16 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "_shell"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_shell"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -7189,6 +7197,9 @@
   "conflicts": [
     [
       "new_session_directive"
+    ],
+    [
+      "new_window_directive"
     ],
     [
       "server_access_directive"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5871,6 +5871,7 @@
   {
     "type": "file",
     "named": true,
+    "root": true,
     "fields": {},
     "children": {
       "multiple": true,

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,11 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +31,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -47,6 +53,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {
@@ -78,6 +85,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -92,7 +105,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -108,13 +121,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -128,15 +141,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -144,7 +165,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/test/corpus/example.txt
+++ b/test/corpus/example.txt
@@ -3,6 +3,8 @@ Example
 =======
 
 # https://github.com/tmux-plugins/tpm
+bind v split-window -h -c "#{pane_current_path}"
+bind v split-window -h
 set -g @plugin tmux-plugins/tpm
 setw -g pane-base-index 1
 set -g word-separators ' -_@'
@@ -52,6 +54,23 @@ new_window'
 
 (file
   (comment)
+  (bind_key_directive
+    (command)
+    (key)
+    (split_window_directive
+      (command)
+      (command_line_option)
+      (command_line_option)
+      (start_directory
+        (string
+          (variable
+            (variable_name))))))
+  (bind_key_directive
+    (command)
+    (key)
+    (split_window_directive
+      (command)
+      (command_line_option)))
   (set_option_directive
     (command)
     (command_line_option)

--- a/test/corpus/new-window.txt
+++ b/test/corpus/new-window.txt
@@ -1,0 +1,297 @@
+===========
+Simple
+===========
+
+new-window
+neww
+new-window top
+neww top
+
+---
+
+(file
+  (new_window_directive
+    (command))
+  (new_window_directive
+    (command))
+  (new_window_directive
+    (command)
+    (shell))
+  (new_window_directive
+    (command)
+    (shell)))
+
+====================
+Flags
+====================
+
+new-window -a
+new-window -b
+new-window -d
+new-window -k
+new-window -P
+new-window -S
+new-window -abdkPS
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option))
+  (new_window_directive
+    (command)
+    (command_line_option)))
+
+====================
+Flags + Shell
+====================
+
+new-window -a top
+new-window -b top
+new-window -d top
+new-window -k top
+new-window -P top
+new-window -S top
+new-window -abdkPS top
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (shell)))
+
+==================
+Options
+==================
+
+new-window -c /tmp
+new-window -e VAR=value
+new-window -e VAR1=value1 -e VAR2=value2
+new-window -F "#{session_name}:#{window_index}"
+new-window -n mywin
+new-window -t :2
+new-window -c /tmp -e VAR=value -e VAR2=value2 -F "#{session_name}:#{window_index}" -n mywin -t :2
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))
+        (variable
+          (variable_name)))))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (window_name))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (window))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))
+        (variable
+          (variable_name))))
+    (command_line_option)
+    (window_name)
+    (command_line_option)
+    (window)))
+
+===============
+Options + Shell
+===============
+
+new-window -c /tmp top
+new-window -e VAR=value top
+new-window -e VAR1=value1 -e VAR2=value2 top
+new-window -F "#{session_name}:#{window_index}" top
+new-window -n mywin top
+new-window -t :2 top
+new-window -c /tmp -e VAR=value -e VAR2=value2 -F "#{session_name}:#{window_index}" -n mywin  -t :2 top
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))
+        (variable
+          (variable_name))))
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (window_name)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (window)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))
+        (variable
+          (variable_name))))
+    (command_line_option)
+    (window_name)
+    (command_line_option)
+    (window)
+    (shell)))
+
+===============
+Complex
+===============
+
+new-window -P -F "#{window_id}" -n scratch vim
+new-window -e VAR1=foo -e VAR2=bar -n envtest bash
+new-window -k -t :3
+neww -c ~/projects -t :2 "make build"
+
+new-window -c "#{pane_current_path}"
+
+---
+
+(file
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (format
+      (string
+        (variable
+          (variable_name))))
+    (command_line_option)
+    (window_name)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (environment)
+    (command_line_option)
+    (window_name)
+    (shell))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (command_line_option)
+    (window))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory)
+    (command_line_option)
+    (window)
+    (string))
+  (new_window_directive
+    (command)
+    (command_line_option)
+    (start_directory
+      (string
+        (variable
+          (variable_name))))))
+

--- a/test/corpus/new-window.txt
+++ b/test/corpus/new-window.txt
@@ -251,6 +251,7 @@ new-window -k -t :3
 neww -c ~/projects -t :2 "make build"
 
 new-window -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
 
 ---
 
@@ -293,5 +294,15 @@ new-window -c "#{pane_current_path}"
     (start_directory
       (string
         (variable
-          (variable_name))))))
+          (variable_name)))))
+  (bind_key_directive
+    (command)
+    (key)
+    (new_window_directive
+      (command)
+      (command_line_option)
+      (start_directory
+        (string
+          (variable
+            (variable_name)))))))
 

--- a/test/corpus/new-window.txt
+++ b/test/corpus/new-window.txt
@@ -305,4 +305,3 @@ bind c new-window -c "#{pane_current_path}"
         (string
           (variable
             (variable_name)))))))
-


### PR DESCRIPTION
# Problem

I have found that in my personal `tmux.conf` there are quite a few syntax highlighting issues when inspecting tree-sitter I found that there are quite a few errors in the tree. When investigating GitHub issues I found #26 and #20 which was some of what I was experiencing.

---

Also just wanted to say thanks for the work you put into this project, I appreciate syntax highlighting 🖍️ 😄 

# Solution

Reviewing previous PRs it seems like the preference is to break them up when possible, so that is what I did here
*(If that is not preferred then just use PR #27 and close this one and #29)*. 

**If merging PRs one at a time this should be merged second.**

Contains the following and is specifically targeted to fixing `new-window` command:

One of the main issues I found was `_end` contains `optional($._space)` which messes with a lot of commands. If I am being 100% honest I don't completely understand the fix. But it was causing tree-sitter to reduce early in quite a few instances. Because of my lack of certainty I ended up writing more tests which all seemed to have positive results.

Changed `new-window` so `shell` isn't required. When looking at [latest man for tmux](https://man7.org/linux/man-pages/man1/tmux.1.html#COMMANDS) it specifically states.
>If shell-command is not specified, the value of the default-command option is used.

# Test Results

The following are test results based on the new tests I had written [here](https://github.com/NicholasMata/tree-sitter-tmux/tree/fixes/grammar-issues/test/corpus) 
The `Example (Updated)` test being referred to below is the updated one which is apart of this branch. The updated one contains two more cases and all the original `Example` tests.

*This branch does contain the ` new-window.txt` test file.*

Current main branch results for updated tests:
```
  example:
      1. ✗ Example (Updated)
  new-session:
      2. ✓ new-session: Simple
      3. ✓ new-session: Flags
      4. ✗ new-session: Flags + Shell
      5. ✓ new-session: Options
      6. ✗ new-session: Options + Shell
      7. ✓ new-session: Group (–t)
      8. ✗ new-session: Complex
  new-window:
      9. ✗ Simple
     10. ✗ Flags
     11. ✓ Flags + Shell
     12. ✗ Options
     13. ✓ Options + Shell
     14. ✗ Complex
  select-pane:
     15. ✓ select-pane: Simple
     16. ✓ select-pane: Flags
     17. ✓ select-pane: Options
     18. ✓ select-pane: Flags + Options
     19. ✗ select-pane: Complex
  select-window:
     20. ✓ select-window: Simple
     21. ✓ select-window: Flags
     22. ✓ select-window: Options
     23. ✓ select-window: Flags + Options
     24. ✗ select-window: Complex
  split-window:
     25. ✓ split-window: Simple
     26. ✗ split-window: Flags
     27. ✗ split-window: Options
     28. ✗ split-window: Options + Shell
     29. ✗ split-window: Flags + Options
     30. ✗ split-window: Empty shell and stdin
     31. ✗ split-window: Complex
```

After changes from this PR you will notice all `new-window` tests pass
```
  example:
      1. ✓ Example (Updated)
  new-session:
      2. ✓ new-session: Simple
      3. ✓ new-session: Flags
      4. ✗ new-session: Flags + Shell
      5. ✓ new-session: Options
      6. ✗ new-session: Options + Shell
      7. ✓ new-session: Group (–t)
      8. ✗ new-session: Complex
  new-window:
      9. ✓ Simple
     10. ✓ Flags
     11. ✓ Flags + Shell
     12. ✓ Options
     13. ✓ Options + Shell
     14. ✓ Complex
  select-pane:
     15. ✓ select-pane: Simple
     16. ✓ select-pane: Flags
     17. ✓ select-pane: Options
     18. ✓ select-pane: Flags + Options
     19. ✗ select-pane: Complex
  select-window:
     20. ✓ select-window: Simple
     21. ✓ select-window: Flags
     22. ✓ select-window: Options
     23. ✓ select-window: Flags + Options
     24. ✗ select-window: Complex
  split-window:
     25. ✓ split-window: Simple
     26. ✓ split-window: Flags
     27. ✓ split-window: Options
     28. ✓ split-window: Options + Shell
     29. ✓ split-window: Flags + Options
     30. ✓ split-window: Empty shell and stdin
     31. ✓ split-window: Complex
```

*This is my first Tree-sitter grammar change. I relied on tests to guide the fixes and kept the diff minimal. I’m happy to make changes if there’s a cleaner approach.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for the new-window command: shell argument is now optional and parser disambiguates it from similar directives.
  * Improved language metadata and lexer logging for better diagnostics.

* **Bug Fixes**
  * Stricter line-end handling: trailing spaces before newlines are now rejected.

* **Tests**
  * Added comprehensive test corpus for new-window scenarios.
  * Added example key bindings for horizontal pane splits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->