### PR TITLE
fix: resize-pane parsing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -8,6 +8,7 @@ module.exports = grammar({
   // final argument is optional
   conflicts: ($) => [
     [$.new_session_directive],
+    [$.resize_pane_directive],
     [$.server_access_directive],
     [$.set_environment_directive],
     [$.show_environment_directive],
@@ -573,7 +574,7 @@ module.exports = grammar({
         $,
         choice("resize-pane", "resizep"),
         cmd_opts(options($, "DLMRTUZ"), $._target_pane, $._width, $._height),
-        $.adjustment
+        optional($.adjustment)
       ),
     resize_window_directive: ($) =>
       command(
@@ -888,7 +889,7 @@ module.exports = grammar({
     comment: (_) => /#[^\n]*/,
     _eol: (_) => /\r?\n/,
     _space: (_) => prec(-1, repeat1(/[ \t]/)),
-    _end: ($) => seq(optional($._space), optional($.comment), $._eol),
+    _end: ($) => seq(optional($.comment), $._eol),
   },
 });
 

--- a/test/corpus/resize-pane.txt
+++ b/test/corpus/resize-pane.txt
@@ -1,0 +1,131 @@
+========================================
+resize-pane: Simple
+========================================
+
+resize-pane
+resizep
+
+---
+
+    (file
+      (resize_pane_directive
+        (command))
+      (resize_pane_directive
+        (command)))
+
+========================================
+resize-pane: Simple flags
+========================================
+
+resize-pane -D 5
+resize-pane -L 5
+resize-pane -M 5
+resize-pane -R 5
+resize-pane -T 5
+resize-pane -U 5
+
+---
+
+    (file
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (adjustment))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (adjustment))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (adjustment))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (adjustment))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (adjustment))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (adjustment)))
+
+========================================
+resize-pane: x, y
+========================================
+
+resize-pane -x 1
+resize-pane -y 1
+resize-pane -x 1 -y 1
+
+---
+
+    (file
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (width))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (height))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (width)
+        (command_line_option)
+        (height)))
+
+========================================
+resize-pane: target pane
+========================================
+resize-pane -t 1 -x 1
+resize-pane -t 1 -y 1
+resize-pane -t 1 -x 1 -y 1
+resize-pane -t 1 -D 5
+
+---
+
+    (file
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (pane)
+        (command_line_option)
+        (width))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (pane)
+        (command_line_option)
+        (height))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (pane)
+        (command_line_option)
+        (width)
+        (command_line_option)
+        (height))
+      (resize_pane_directive
+        (command)
+        (command_line_option)
+        (pane)
+        (command_line_option)
+        (adjustment)))
+
+========================================
+resize-pane: Z takes no argument
+========================================
+
+resize-pane -Z
+
+---
+
+    (file
+      (resize_pane_directive
+        (command)
+        (command_line_option)))
+


### PR DESCRIPTION
resize-pane -Z doesn't take an argument

Uses the same `_end` fix as discussed in #27