### PR TITLE
feat: add support for environment variables

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -39,6 +39,7 @@ module.exports = grammar({
         $.display_message_directive,
         $.display_panes_directive,
         $.display_popup_directive,
+        $.environment_assignment,
         $.find_window_directive,
         $.has_session_directive,
         $.if_shell_directive,
@@ -334,6 +335,13 @@ module.exports = grammar({
         ),
         $._shell
       ),
+    _env_variable_name: (_) => /[A-Za-z_][A-Za-z0-9_]*/,
+    environment_assignment: ($) =>
+      prec.right(seq(
+        field('name', alias($._env_variable_name, $.name)),
+        '=',
+        field('value', alias(optional($._string), $.value))
+      )),
     find_window_directive: ($) =>
       command(
         $,
@@ -888,7 +896,7 @@ module.exports = grammar({
     comment: (_) => /#[^\n]*/,
     _eol: (_) => /\r?\n/,
     _space: (_) => prec(-1, repeat1(/[ \t]/)),
-    _end: ($) => seq(optional($._space), optional($.comment), $._eol),
+    _end: ($) => seq(optional($.comment), $._eol),
   },
 });
 

--- a/test/corpus/env-var.txt
+++ b/test/corpus/env-var.txt
@@ -1,0 +1,20 @@
+========================================
+environment variables
+========================================
+
+MYVAR=
+MYVAR=value
+TMUX_FZF_LAUNCH_KEY="C-t"
+
+---
+
+    (file
+      (environment_assignment
+        (name))
+      (environment_assignment
+        (name)
+        (value))
+      (environment_assignment
+        (name)
+        (value
+          (string))))


### PR DESCRIPTION
Setting environment variables is valid inside of tmux.conf and some plugins suggest it, e.g.:

https://github.com/sainnhe/tmux-fzf#key-binding

Uses the same `_end` fix as discussed in #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added support for environment variable assignments (e.g., NAME=value) as top-level commands, including optional quoted values and name validation.
* Bug Fixes
  * Improved end-of-line parsing: allows trailing comments before newline and tightens leading whitespace handling for more predictable parsing.
* Tests
  * Added test coverage for environment variable assignments and their parsed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->