### PR TITLE
feat: support for statements separated by ;

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -15,7 +15,9 @@ module.exports = grammar({
   ],
 
   rules: {
-    file: ($) => repeat(seq(optional($._command), $._end)),
+    file: ($) => repeat(seq(optional($._statement_list), $._end)),
+
+    _statement_list: ($) => sep1($._command, ';'),
 
     _command: ($) =>
       choice(
@@ -888,7 +890,7 @@ module.exports = grammar({
     comment: (_) => /#[^\n]*/,
     _eol: (_) => /\r?\n/,
     _space: (_) => prec(-1, repeat1(/[ \t]/)),
-    _end: ($) => seq(optional($._space), optional($.comment), $._eol),
+    _end: ($) => seq(optional($.comment), $._eol),
   },
 });
 

--- a/test/corpus/compound-statements.txt
+++ b/test/corpus/compound-statements.txt
@@ -1,0 +1,23 @@
+========================================
+statements with ;
+========================================
+
+unbind-key -T copy-mode-vi v ; bind-key -T copy-mode-vi v send-keys -X begin-selection
+
+---
+
+    (file
+      (unbind_key_directive
+        (command)
+        (command_line_option)
+        (key_table)
+        (key))
+      (bind_key_directive
+        (command)
+        (command_line_option)
+        (key_table)
+        (key)
+        (send_keys_directive
+          (command)
+          (command_line_option)
+          (key))))


### PR DESCRIPTION
Uses the same `_end` fix as discussed in #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now write multiple commands on a single line using semicolons to separate them.
- Bug Fixes
  - Improved end-of-line parsing consistency: supports an optional trailing comment; extraneous trailing whitespace is no longer tolerated.
- Tests
  - Added corpus tests covering semicolon-separated compound statements to ensure correct parsing and representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->